### PR TITLE
Add configurable packet lifetime on instantiation

### DIFF
--- a/contracts/cw-ibc-queries/src/ibc.rs
+++ b/contracts/cw-ibc-queries/src/ibc.rs
@@ -12,10 +12,6 @@ use cw_ibc_query::{
 use crate::error::ContractError;
 use crate::state::PENDING;
 
-// TODO: make configurable?
-/// packets live one hour
-pub const PACKET_LIFETIME: u64 = 60 * 60;
-
 #[entry_point]
 /// enforces ordering and versioing constraints
 pub fn ibc_channel_open(
@@ -183,7 +179,14 @@ mod tests {
         let env = mock_env();
 
         let ack = IbcAcknowledgement::new([]);
-        let ibc_res = mock_ibc_packet_ack(CHANNEL, &InstantiateMsg {}, ack).unwrap();
+        let ibc_res = mock_ibc_packet_ack(
+            CHANNEL,
+            &InstantiateMsg {
+                packet_lifetime: 60u64,
+            },
+            ack,
+        )
+        .unwrap();
         let res = acknowledge_query(deps.as_mut(), env, String::from("test"), ibc_res);
         assert!(res.is_ok());
     }

--- a/contracts/cw-ibc-queries/src/msg.rs
+++ b/contracts/cw-ibc-queries/src/msg.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 /// Just needs to know the code_id of a reflect contract to spawn sub-accounts
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {}
+pub struct InstantiateMsg {
+    pub packet_lifetime: u64,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/contracts/cw-ibc-queries/src/state.rs
+++ b/contracts/cw-ibc-queries/src/state.rs
@@ -1,3 +1,4 @@
 use cw_storage_plus::Item;
 
 pub const PENDING: Item<String> = Item::new("pending");
+pub const PACKET_LIFETIME: Item<u64> = Item::new("packet_lifetime");


### PR DESCRIPTION
This PR adds the possibility to configure the packet lifetime at instantiation of the contract.

Thought to make it updatable with an `ExecuteMsg` but I believe it defeats the purpose of this contract which is to show the IBC queries functionality. 